### PR TITLE
Releasing: cleanup + ignore homebrew.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,10 +60,10 @@ ifeq ($(GOOS),windows)
 	SUFFIX=.exe
 endif
 
-build: $(PREFIX)bin/manifold$(SUFFIX)
+build: $(PREFIX)bin/terraform-provider-manifold$(SUFFIX)
 
-$(PREFIX)bin/manifold$(SUFFIX):
-	$(GO_BUILD) -o $(PREFIX)bin/manifold$(SUFFIX) .
+$(PREFIX)bin/terraform-provider-manifold$(SUFFIX):
+	$(GO_BUILD) -o $(PREFIX)bin/terraform-provider-manifold$(SUFFIX) .
 
 .PHONY: build
 
@@ -77,17 +77,17 @@ OS_ARCH= \
 os=$(word 1,$(subst _, ,$1))
 arch=$(word 2,$(subst _, ,$1))
 
-os-build/windows_amd64/bin/manifold: os-build/%/bin/manifold:
-	PREFIX=build/$*/ GOOS=$(call os,$*) GOARCH=$(call arch,$*) make build/$*/bin/manifold.exe
-$(NO_WINDOWS:%=os-build/%/bin/manifold): os-build/%/bin/manifold:
-	PREFIX=build/$*/ GOOS=$(call os,$*) GOARCH=$(call arch,$*) make build/$*/bin/manifold
+os-build/windows_amd64/bin/terraform-provider-manifold: os-build/%/bin/terraform-provider-manifold:
+	PREFIX=build/$*/ GOOS=$(call os,$*) GOARCH=$(call arch,$*) make build/$*/bin/terraform-provider-manifold.exe
+$(NO_WINDOWS:%=os-build/%/bin/terraform-provider-manifold): os-build/%/bin/terraform-provider-manifold:
+	PREFIX=build/$*/ GOOS=$(call os,$*) GOARCH=$(call arch,$*) make build/$*/bin/terraform-provider-manifold
 
-build/manifold-cli_$(VERSION)_windows_amd64.zip: build/manifold-cli_$(VERSION)_%.zip: os-build/%/bin/manifold
-	cd build/$*/bin; zip -r ../../manifold-cli_$(VERSION)_$*.zip manifold.exe
-$(NO_WINDOWS:%=build/manifold-cli_$(VERSION)_%.tar.gz): build/manifold-cli_$(VERSION)_%.tar.gz: os-build/%/bin/manifold
-	cd build/$*/bin; tar -czf ../../manifold-cli_$(VERSION)_$*.tar.gz manifold
+build/terraform-provider-manifold_$(VERSION)_windows_amd64.zip: build/terraform-provider-manifold_$(VERSION)_%.zip: os-build/%/bin/terraform-provider-manifold
+	cd build/$*/bin; zip -r ../../terraform-provider-manifold_$(VERSION)_$*.zip terraform-provider-manifold.exe
+$(NO_WINDOWS:%=build/terraform-provider-manifold_$(VERSION)_%.tar.gz): build/terraform-provider-manifold_$(VERSION)_%.tar.gz: os-build/%/bin/terraform-provider-manifold
+	cd build/$*/bin; tar -czf ../../terraform-provider-manifold_$(VERSION)_$*.tar.gz terraform-provider-manifold
 
-zips: $(NO_WINDOWS:%=build/manifold-cli_$(VERSION)_%.tar.gz) build/manifold-cli_$(VERSION)_windows_amd64.zip
+zips: $(NO_WINDOWS:%=build/terraform-provider-manifold_$(VERSION)_%.tar.gz) build/terraform-provider-manifold_$(VERSION)_windows_amd64.zip
 
 release: zips
 	curl -LO https://releases.manifold.co/promulgate/$(PROMULGATE_VERSION)/promulgate_$(PROMULGATE_VERSION)_linux_amd64.tar.gz

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 VERSION?=$(shell git describe --tags --dirty | sed 's/^v//')
 PKG=github.com/manifoldco/terraform-provider-manifold
 GO_BUILD=CGO_ENABLED=0 go build -i --ldflags="-w -X $(PKG)/config.Version=$(VERSION)"
-PROMULGATE_VERSION=0.0.8
+PROMULGATE_VERSION=0.0.9
 
 LINTERS=\
     gofmt \
@@ -92,6 +92,6 @@ zips: $(NO_WINDOWS:%=build/terraform-provider-manifold_$(VERSION)_%.tar.gz) buil
 release: zips
 	curl -LO https://releases.manifold.co/promulgate/$(PROMULGATE_VERSION)/promulgate_$(PROMULGATE_VERSION)_linux_amd64.tar.gz
 	tar xvf promulgate_*
-	./promulgate release v$(VERSION)
+	./promulgate release --homebrew=false v$(VERSION)
 
 .PHONY: release zips $(OS_ARCH:%=os-build/%/bin/manifold)


### PR DESCRIPTION
Due to copy-paste, we were still using the `manifold` binary names, this moves
that over to the new format, `terraform-provider-manifold`.

This also uses the latest version of Promulgate (once https://github.com/manifoldco/promulgate/pull/20) is released
to ignore Homebrew releasing.