### PR TITLE
Implement credentials data source.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ bootstrap: $(BOOTSTRAP)
 	gometalinter --install
 
 vendor: Gopkg.lock
-	dep ensure
+	dep ensure -v --vendor-only
 
 .PHONY: bootstrap $(BOOTSTRAP)
 
@@ -47,6 +47,8 @@ METALINT=gometalinter --tests --disable-all --vendor --deadline=5m -s data \
 
 $(LINTERS): vendor
 	$(METALINT) $@
+
+lint: $(LINTERS)
 
 .PHONY: $(LINTERS) test
 

--- a/_examples/manifold-resource-credential/main.tf
+++ b/_examples/manifold-resource-credential/main.tf
@@ -1,0 +1,6 @@
+data "manifold_credential" "my-credential" {
+  project  = "terraform"
+  resource = "custom-resource1-1"
+  key      = "MY_CREDENTIAL_KEY"
+  default  = "my-value"
+}

--- a/manifold/data_source_manifold_credential.go
+++ b/manifold/data_source_manifold_credential.go
@@ -56,12 +56,18 @@ func resourceManifoldResourceCredentialRead(d *schema.ResourceData, meta interfa
 		return err
 	}
 
+	var defValue string
+	def, ok := d.GetOkExists("default")
+	if ok {
+		defValue = def.(string)
+	}
+
 	rs := &primitives.Resource{
 		Name: d.Get("resource").(string),
 		Credentials: []*primitives.Credential{
 			{
 				Key:     d.Get("key").(string),
-				Default: d.Get("default").(string),
+				Default: defValue,
 			},
 		},
 	}

--- a/manifold/data_source_manifold_credential.go
+++ b/manifold/data_source_manifold_credential.go
@@ -1,0 +1,91 @@
+package manifold
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/manifoldco/go-manifold/integrations"
+	"github.com/manifoldco/go-manifold/integrations/primitives"
+)
+
+func dataSourceManifoldCredential() *schema.Resource {
+	return &schema.Resource{
+		Read: resourceManifoldResourceCredentialRead,
+
+		Schema: map[string]*schema.Schema{
+			"project": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The project label you want to get the resource for.",
+			},
+
+			"resource": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "The resource label you want to get the resource for",
+			},
+
+			"key": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "The key to fetch from the resource credentials.",
+			},
+
+			"default": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The default value for this key if it's not set.",
+			},
+
+			"value": {
+				Type:        schema.TypeString,
+				Sensitive:   true,
+				Computed:    true,
+				Description: "The value of the credential",
+			},
+		},
+	}
+}
+
+func resourceManifoldResourceCredentialRead(d *schema.ResourceData, meta interface{}) error {
+	cl := meta.(*integrations.Client)
+	ctx := context.Background()
+
+	projectLabel, _, err := getProjectInformation(cl, d.Get("project").(string), false)
+	if err != nil {
+		return err
+	}
+
+	rs := &primitives.Resource{
+		Name: d.Get("resource").(string),
+		Credentials: []*primitives.Credential{
+			{
+				Key:     d.Get("key").(string),
+				Default: d.Get("default").(string),
+			},
+		},
+	}
+	resource, err := cl.GetResource(ctx, projectLabel, rs)
+	if err != nil {
+		return err
+	}
+
+	cv, err := cl.GetResourceCredentialValues(ctx, projectLabel, rs)
+	if err != nil {
+		return err
+	}
+
+	credMap, err := integrations.FlattenResourceCredentialValues(cv)
+	if err != nil {
+		return err
+	}
+	cred := credMap[d.Get("key").(string)]
+
+	d.SetId(resource.ID.String())
+	d.Set("resource", resource.Body.Label)
+	d.Set("value", cred)
+	if projectLabel != nil {
+		d.Set("project", *projectLabel)
+	}
+	return nil
+}

--- a/manifold/data_source_manifold_credential_test.go
+++ b/manifold/data_source_manifold_credential_test.go
@@ -1,0 +1,83 @@
+package manifold_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestManifoldDataSource_CredentialBasic(t *testing.T) {
+	t.Run("with a filtered configuration", func(t *testing.T) {
+		conf := `
+data "manifold_credential" "my-credential" {
+	project = "terraform"
+	resource = "custom-resource1-1"
+	key = "TOKEN_ID"
+}
+`
+
+		resource.Test(t, resource.TestCase{
+			PreCheck:  testProviderPreCheck(t),
+			Providers: testProviders,
+			Steps: []resource.TestStep{
+				{
+					Config: conf,
+					Check: resource.ComposeTestCheckFunc(
+						resource.TestCheckResourceAttrSet("data.manifold_credential.my-credential", "id"),
+						resource.TestCheckResourceAttr("data.manifold_credential.my-credential", "project", "terraform"),
+						resource.TestCheckResourceAttr("data.manifold_credential.my-credential", "resource", "custom-resource1-1"),
+						testAccCheckManifoldCredential("data.manifold_credential.my-credential", "my-secret-token-id"),
+					),
+				},
+			},
+		})
+	})
+
+	t.Run("with a non existing key", func(t *testing.T) {
+		t.Run("with a default value", func(t *testing.T) {
+			conf := `
+data "manifold_credential" "my-credential" {
+	project = "terraform"
+	resource = "custom-resource1-1"
+	key = "NON_EXISTING_FIELD"
+	default = "my-value"
+}
+`
+
+			resource.Test(t, resource.TestCase{
+				PreCheck:  testProviderPreCheck(t),
+				Providers: testProviders,
+				Steps: []resource.TestStep{
+					{
+						Config: conf,
+						Check: resource.ComposeTestCheckFunc(
+							resource.TestCheckResourceAttrSet("data.manifold_credential.my-credential", "id"),
+							resource.TestCheckResourceAttr("data.manifold_credential.my-credential", "project", "terraform"),
+							resource.TestCheckResourceAttr("data.manifold_credential.my-credential", "resource", "custom-resource1-1"),
+							testAccCheckManifoldCredential("data.manifold_credential.my-credential", "my-value"),
+						),
+					},
+				},
+			})
+		})
+	})
+}
+
+func testAccCheckManifoldCredential(n, value string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rn, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Resource not found")
+		}
+		out, ok := rn.Primary.Attributes["value"]
+		if !ok {
+			return fmt.Errorf("Attribute 'value' not found: %#v", rn.Primary.Attributes)
+		}
+		if out != value {
+			return fmt.Errorf("Value should be '%s', got '%s'", value, out)
+		}
+		return nil
+	}
+}

--- a/manifold/provider.go
+++ b/manifold/provider.go
@@ -40,8 +40,9 @@ func Provider() terraform.ResourceProvider {
 		},
 
 		DataSourcesMap: map[string]*schema.Resource{
-			"manifold_resource": dataSourceManifoldResource(),
-			"manifold_project":  dataSourceManifoldProject(),
+			"manifold_resource":   dataSourceManifoldResource(),
+			"manifold_project":    dataSourceManifoldProject(),
+			"manifold_credential": dataSourceManifoldCredential(),
 		},
 
 		ConfigureFunc: providerConfigure,

--- a/manifold/provider.go
+++ b/manifold/provider.go
@@ -36,7 +36,8 @@ func Provider() terraform.ResourceProvider {
 		},
 
 		ResourcesMap: map[string]*schema.Resource{
-			"manifold_api_token": resourceManifoldToken(),
+			"manifold_api_token":  resourceManifoldToken(),
+			"manifold_credential": resourceManifoldCredential(),
 		},
 
 		DataSourcesMap: map[string]*schema.Resource{

--- a/manifold/resource_manifold_credential.go
+++ b/manifold/resource_manifold_credential.go
@@ -1,0 +1,126 @@
+package manifold
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform/helper/schema"
+	manifold "github.com/manifoldco/go-manifold"
+	"github.com/manifoldco/go-manifold/integrations"
+	"github.com/manifoldco/go-manifold/integrations/primitives"
+)
+
+func resourceManifoldCredential() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceManifoldCredentialCreate,
+		Read:   resourceManifoldResourceCredentialRead,
+		Update: resourceManifoldCredentialUpdate,
+		Delete: resourceManifoldCredentialDelete,
+
+		Schema: map[string]*schema.Schema{
+			"project": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The project label you want to get the resource for.",
+			},
+
+			"resource": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "The resource label you want to get the resource for",
+			},
+
+			"key": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "The key to fetch from the resource credentials.",
+			},
+
+			"value": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Sensitive:   true,
+				Description: "The value of the credential",
+			},
+		},
+	}
+}
+
+func resourceManifoldCredentialCreate(d *schema.ResourceData, meta interface{}) error {
+	cl := meta.(*integrations.Client)
+	ctx := context.Background()
+
+	cfg, err := configFromSchema(ctx, cl, d)
+	if err != nil {
+		return err
+	}
+
+	if err := patchConfig(ctx, cl, cfg); err != nil {
+		return err
+	}
+
+	d.SetId(cfg.key)
+	return nil
+}
+
+func resourceManifoldCredentialUpdate(d *schema.ResourceData, meta interface{}) error {
+	cl := meta.(*integrations.Client)
+	ctx := context.Background()
+
+	cfg, err := configFromSchema(ctx, cl, d)
+	if err != nil {
+		return err
+	}
+
+	if err := patchConfig(ctx, cl, cfg); err != nil {
+		return err
+	}
+
+	d.SetId(cfg.key)
+	return nil
+}
+
+func resourceManifoldCredentialDelete(d *schema.ResourceData, meta interface{}) error {
+	cl := meta.(*integrations.Client)
+	ctx := context.Background()
+
+	cfg, err := configFromSchema(ctx, cl, d)
+	if err != nil {
+		return err
+	}
+	cfg.value = nil
+
+	return patchConfig(ctx, cl, cfg)
+}
+
+type schemaConfig struct {
+	resourceID manifold.ID
+	key        string
+	value      *string
+}
+
+func configFromSchema(ctx context.Context, cl *integrations.Client, d *schema.ResourceData) (schemaConfig, error) {
+	projectLabel, _, err := getProjectInformation(cl, d.Get("project").(string), false)
+	if err != nil {
+		return schemaConfig{}, err
+	}
+
+	res := &primitives.Resource{Name: d.Get("resource").(string)}
+	resource, err := cl.GetResource(ctx, projectLabel, res)
+	if err != nil {
+		return schemaConfig{}, err
+	}
+
+	return schemaConfig{
+		resourceID: resource.ID,
+		key:        d.Get("key").(string),
+		value:      ptrString(d.Get("value").(string)),
+	}, nil
+}
+
+func patchConfig(ctx context.Context, cl *integrations.Client, cfg schemaConfig) error {
+	data := map[string]interface{}{
+		cfg.key: cfg.value,
+	}
+	_, err := cl.Resources.UpdateConfig(ctx, cfg.resourceID, &data)
+	return err
+}

--- a/manifold/resource_manifold_credential_test.go
+++ b/manifold/resource_manifold_credential_test.go
@@ -1,0 +1,76 @@
+package manifold_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/terraform"
+
+	"github.com/manifoldco/go-manifold/integrations"
+	"github.com/manifoldco/go-manifold/integrations/primitives"
+)
+
+func TestManifoldResource_CustomCredential(t *testing.T) {
+	conf := `
+resource "manifold_credential" "test_credential" {
+	project = "terraform"
+	resource = "custom-resource3-1"
+	key = "NEW_KEY"
+	value = "my-value"
+}
+`
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     testProviderPreCheck(t),
+		Providers:    testProviders,
+		CheckDestroy: testAPICredentialDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: conf,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("manifold_credential.test_credential", "id"),
+					resource.TestCheckResourceAttrSet("manifold_credential.test_credential", "value"),
+				),
+			},
+		},
+	})
+}
+
+func testAPICredentialDestroy(s *terraform.State) error {
+	cl := testProviders["manifold"].(*schema.Provider).Meta().(*integrations.Client)
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "manifold_credential" {
+			continue
+		}
+		ctx := context.Background()
+
+		projectLabel := rs.Primary.Attributes["project"]
+		resourceLabel := rs.Primary.Attributes["resource"]
+
+		res := &primitives.Resource{Name: resourceLabel}
+		resource, err := cl.GetResource(ctx, &projectLabel, res)
+		if err != nil {
+			return err
+		}
+
+		credentials, err := cl.Resources.GetConfig(ctx, resource.ID)
+		if err != nil {
+			return err
+		}
+
+		if credentials == nil {
+			return nil
+		}
+
+		creds := *credentials
+		if _, ok := creds[rs.Primary.Attributes["key"]]; ok {
+			return fmt.Errorf("Credential '%s' still exists", rs.Primary.ID)
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
We've seen issues where the entire value of a set of credentials for a
resource/project gets cached and only being refreshed on `apply`.

When a user wants to use a new credential, this can cause issues. When
running `plan`, the value isn't available yet but the user might want to
reference this already. It only becomes available on `apply` when the
structure is changed, which it doesn't until we reference the new key.
Which in turn we can't unless it's being refreshed.

By referencing key per key, we introduce a mechanic that allows people to
not run into this issue. It does however means that users have to add extra
credentials.